### PR TITLE
Fix Javadoc exclusion of MD-SAL-generated code

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -69,7 +69,6 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-javadoc-plugin</artifactId>
          <configuration>
-           <sourcepath>*/target/generated-sources/mdsal-binding/*</sourcepath>
            <excludePackageNames>*</excludePackageNames>
          </configuration>
        </plugin>
@@ -82,7 +81,6 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <sourcepath>*/target/generated-sources/mdsal-binding/*</sourcepath>
           <excludePackageNames>*</excludePackageNames>
         </configuration>
       </plugin>

--- a/ordmodels/common/pom.xml
+++ b/ordmodels/common/pom.xml
@@ -27,4 +27,28 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
       <artifactId>rfc6991-ietf-yang-types</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/ordmodels/device/pom.xml
+++ b/ordmodels/device/pom.xml
@@ -77,11 +77,21 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-javadoc-plugin</artifactId>
          <configuration>
-           <sourcepath>*/target/generated-sources/mdsal-binding/*</sourcepath>
            <excludePackageNames>*</excludePackageNames>
          </configuration>
        </plugin>
      </plugins>
   </build>
 
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/ordmodels/network/pom.xml
+++ b/ordmodels/network/pom.xml
@@ -45,4 +45,28 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
       <artifactId>rfc8345</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/ordmodels/pom.xml
+++ b/ordmodels/pom.xml
@@ -44,14 +44,6 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
           <skip>true</skip>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <sourcepath>*/target/generated-sources/mdsal-binding/*</sourcepath>
-          <excludePackageNames>*</excludePackageNames>
-        </configuration>
-      </plugin>
 <!-- skipping test since this is a util project / folder -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -64,16 +56,4 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <sourcepath>*/target/generated-sources/mdsal-binding/*</sourcepath>
-          <excludePackageNames>*</excludePackageNames>
-        </configuration>
-      </plugin>
-    </plugins>
-  </reporting>
 </project>

--- a/ordmodels/service/pom.xml
+++ b/ordmodels/service/pom.xml
@@ -39,4 +39,28 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
       <artifactId>rfc6991-ietf-yang-types</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,14 +62,6 @@ and is available at http://www.eclipse.org/legal/epl-v10.html INTERNAL
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <sourcepath>*/target/generated-sources/mdsal-binding/*</sourcepath>
-                    <excludePackageNames>*</excludePackageNames>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/tapimodels/pom.xml
+++ b/tapimodels/pom.xml
@@ -21,4 +21,27 @@ and is available at http://www.eclipse.org/legal/epl-v10.html
   <version>3.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <excludePackageNames>*</excludePackageNames>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
By explicitly adding `maven-javadoc-plugin` configurations to POMs of all relevant sub-packages, removing the exclusion definitions from their parent packages, and removing non-working `<sourcepath>` entries