### PR TITLE
lighty: Improve dependency versions and make a few code changes to stay backwards-compatible

### DIFF
--- a/lighty/pom.xml
+++ b/lighty/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-app-parent</artifactId>
-        <version>13.0.0</version>
+        <version>13.2.1</version>
         <!--
         lighty-core is usually released a few days before the official Opendaylight release.
         13.0.0 = Aluminium release of 2020/09/18

--- a/lighty/pom.xml
+++ b/lighty/pom.xml
@@ -28,7 +28,7 @@
         <application.main.class>io.lighty.controllers.tpce.Main</application.main.class>
         <application.attach.zip>true</application.attach.zip>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <transportpce.version>3.0.0-SNAPSHOT</transportpce.version>
+        <transportpce.version>2.3.0</transportpce.version>
     </properties>
 
     <dependencies>

--- a/lighty/src/main/java/io/lighty/controllers/tpce/module/TransportPCEImpl.java
+++ b/lighty/src/main/java/io/lighty/controllers/tpce/module/TransportPCEImpl.java
@@ -62,13 +62,15 @@ import org.opendaylight.transportpce.renderer.provisiondevice.OtnDeviceRendererS
 import org.opendaylight.transportpce.renderer.provisiondevice.RendererServiceOperations;
 import org.opendaylight.transportpce.renderer.provisiondevice.RendererServiceOperationsImpl;
 import org.opendaylight.transportpce.renderer.rpcs.DeviceRendererRPCImpl;
-import org.opendaylight.transportpce.servicehandler.impl.ServicehandlerImpl;
+// import org.opendaylight.transportpce.servicehandler.impl.ServicehandlerImpl;
 import org.opendaylight.transportpce.servicehandler.impl.ServicehandlerProvider;
-import org.opendaylight.transportpce.servicehandler.listeners.NetworkModelListenerImpl;
+// import org.opendaylight.transportpce.servicehandler.listeners.NetworkModelListenerImpl;
 import org.opendaylight.transportpce.servicehandler.listeners.PceListenerImpl;
 import org.opendaylight.transportpce.servicehandler.listeners.RendererListenerImpl;
 import org.opendaylight.transportpce.servicehandler.service.ServiceDataStoreOperations;
 import org.opendaylight.transportpce.servicehandler.service.ServiceDataStoreOperationsImpl;
+import org.opendaylight.transportpce.servicehandler.service.ServiceHandlerOperations;
+import org.opendaylight.transportpce.servicehandler.service.ServiceHandlerOperationsImpl;
 import org.opendaylight.transportpce.tapi.impl.TapiProvider;
 import org.opendaylight.transportpce.tapi.utils.TapiListener;
 import org.opendaylight.yang.gen.v1.http.org.opendaylight.transportpce.networkutils.rev170818.TransportpceNetworkutilsService;
@@ -126,7 +128,7 @@ public class TransportPCEImpl extends AbstractLightyModule implements TransportP
         OpenRoadmInterfaces openRoadmInterfaces = initOpenRoadmInterfaces(mappingUtils);
         PortMapping portMapping = initPortMapping(lightyServices, openRoadmInterfaces);
         NetworkModelService networkModelService = new NetworkModelServiceImpl(networkTransaction, linkDiscoveryImpl,
-                portMapping, lightyServices.getBindingNotificationPublishService());
+                portMapping); // , lightyServices.getBindingNotificationPublishService());
         FrequenciesService networkModelWavelengthService =
                 new FrequenciesServiceImpl(lightyServices.getBindingDataBroker());
         NetConfTopologyListener netConfTopologyListener = new NetConfTopologyListener(networkModelService,
@@ -165,15 +167,21 @@ public class TransportPCEImpl extends AbstractLightyModule implements TransportP
             lightyServices.getBindingNotificationPublishService());
         PceListenerImpl pceListenerImpl = new PceListenerImpl(rendererServiceOperations, pathComputationService,
             lightyServices.getBindingNotificationPublishService(), serviceDataStoreOperations);
+        /*
         NetworkModelListenerImpl networkModelListenerImpl = new NetworkModelListenerImpl(
                 lightyServices.getBindingNotificationPublishService(), serviceDataStoreOperations);
         ServicehandlerImpl servicehandler = new ServicehandlerImpl(lightyServices.getBindingDataBroker(),
             pathComputationService, rendererServiceOperations, lightyServices.getBindingNotificationPublishService(),
-            pceListenerImpl, rendererListenerImpl, networkModelListenerImpl, serviceDataStoreOperations);
+            pceListenerImpl, rendererListenerImpl); // , networkModelListenerImpl, serviceDataStoreOperations);
+        */
+        ServiceHandlerOperations servicehandler = new ServiceHandlerOperationsImpl(lightyServices.getBindingDataBroker(),
+                pathComputationService, rendererServiceOperations, lightyServices.getBindingNotificationPublishService(),
+                pceListenerImpl, rendererListenerImpl);
         servicehandlerProvider = new ServicehandlerProvider(lightyServices.getBindingDataBroker(),
                 lightyServices.getRpcProviderService(), lightyServices.getNotificationService(),
-                serviceDataStoreOperations, pceListenerImpl, rendererListenerImpl, networkModelListenerImpl,
-                servicehandler);
+                pathComputationService, rendererServiceOperations, lightyServices.getBindingNotificationPublishService());
+                // serviceDataStoreOperations, pceListenerImpl, rendererListenerImpl, networkModelListenerImpl,
+                // servicehandler);
         tapiProvider = initTapi(lightyServices, servicehandler);
     }
 
@@ -219,10 +227,10 @@ public class TransportPCEImpl extends AbstractLightyModule implements TransportP
      * Init tapi provider beans.
      *
      * @param lightyServices LightyServices
-     * @param rendererServiceOperations RendererServiceOperations
+     * @param servicehandler ServiceHandlerOperations
      * @return TapiProvider instance
      */
-    private TapiProvider initTapi(LightyServices lightyServices, OrgOpenroadmServiceService servicehandler) {
+    private TapiProvider initTapi(LightyServices lightyServices, /*OrgOpenroadmServiceService*/ ServiceHandlerOperations servicehandler) {
         return new TapiProvider(lightyServices.getBindingDataBroker(), lightyServices.getRpcProviderService(),
                 servicehandler, new TapiListener());
     }

--- a/lighty/src/main/java/io/lighty/controllers/tpce/utils/TPCEUtils.java
+++ b/lighty/src/main/java/io/lighty/controllers/tpce/utils/TPCEUtils.java
@@ -207,8 +207,10 @@ public final class TPCEUtils {
                     .getInstance(),
             org.opendaylight.yang.gen.v1.http.org.opendaylight.transportpce.device.renderer.rev200128
                     .$YangModuleInfoImpl.getInstance(),
+            /*
             org.opendaylight.yang.gen.v1.http.org.opendaylight.transportpce.networkmodel.rev201116
                     .$YangModuleInfoImpl.getInstance(),
+            */
             org.opendaylight.yang.gen.v1.http.org.opendaylight.transportpce.renderer.rev201125.$YangModuleInfoImpl
                     .getInstance(),
             org.opendaylight.yang.gen.v1.http.org.opendaylight.transportpce.servicehandler.rev201125.$YangModuleInfoImpl
@@ -220,7 +222,7 @@ public final class TPCEUtils {
             org.opendaylight.yang.gen.v1.gnpy.path.rev200909.$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.http.org.opendaylight.transportpce.portmapping.rev201012
                     .$YangModuleInfoImpl.getInstance(),
-            org.opendaylight.yang.gen.v1.http.org.transportpce.b.c._interface.pathdescription.rev201210
+            org.opendaylight.yang.gen.v1.http.org.transportpce.b.c._interface.pathdescription.rev201126 // .rev201210
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.http.org.transportpce.b.c._interface.routing.constraints.rev171017
                     .$YangModuleInfoImpl.getInstance(),
@@ -228,8 +230,10 @@ public final class TPCEUtils {
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.http.org.transportpce.b.c._interface.servicepath.rev171017.$YangModuleInfoImpl
                     .getInstance(),
+            /*
             org.opendaylight.yang.gen.v1.http.org.transportpce.d._interface.ord.topology.types.rev201116
                     .$YangModuleInfoImpl.getInstance(),
+            */
             org.opendaylight.yang.gen.v1.http.transportpce.topology.rev201019.$YangModuleInfoImpl.getInstance(),
 
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.iana._if.type.rev170119.$YangModuleInfoImpl


### PR DESCRIPTION
Set `transportpce` dependency to **2.3.0**

* To remove `yangtools` and `mdsal` dependency conflicts between `lighty` **13.x.y** and `transportpce` **3.0.0** libraries

Made a few code changes to stay compatible with `transportpce` **2.3.0**

And updated `lighty-app-parent` from **13.0.0** to **13.2.1**

* To use all the latest `lighty` **13.2.1** libraries

Resolves #3 

Supersedes and invalidates #4 